### PR TITLE
Get a error when script try close a page

### DIFF
--- a/lib/generate/collector/category.js
+++ b/lib/generate/collector/category.js
@@ -39,7 +39,7 @@ const category = async (
 
     merge(bungleConfig.modules, await collectModules(page));
 
-    page.close();
+    await page.close();
 
     logger.success(`Finished collecting modules for bundle "${bundleName}".`);
 

--- a/lib/generate/collector/checkout.js
+++ b/lib/generate/collector/checkout.js
@@ -68,11 +68,11 @@ const checkout = async (
     await page.goto(`${baseUrl}checkout`, { waitUntil: 'networkidle0' });
     const checkoutModules = await collectModules(page);
 
-    page.close();
+    merge(bundleConfig.modules, cartModules, checkoutModules);
+
+    await page.close();
 
     logger.success(`Finished collecting modules for bundle "${bundleName}".`);
-
-    merge(bundleConfig.modules, cartModules, checkoutModules);
 
     return bundleConfig;
 };

--- a/lib/generate/collector/cms.js
+++ b/lib/generate/collector/cms.js
@@ -34,7 +34,7 @@ const cms = async (browserContext, { cmsUrl, authUsername, authPassword }) => {
 
     merge(bundleConfig.modules, await collectModules(page));
 
-    page.close();
+    await page.close();
 
     logger.success(`Finished collecting modules for bundle "${bundleName}".`);
 

--- a/lib/generate/collector/product.js
+++ b/lib/generate/collector/product.js
@@ -37,7 +37,7 @@ const product = async (
 
     merge(bundleConfig.modules, await collectModules(page));
 
-    page.close();
+    await page.close();
 
     logger.success(`Finished collecting modules for bundle "${bundleName}".`);
 


### PR DESCRIPTION
```
✔ checkout - 210 items.                                                                                       14:07:06
(node:7825) UnhandledPromiseRejectionWarning: Error: Protocol error (Target.closeTarget): Target closed.
    at /node_modules/puppeteer/lib/Connection.js:74:56
    at new Promise (<anonymous>)
    at Connection.send (/node_modules/puppeteer/lib/Connection.js:73:12)
    at Page.close (/node_modules/puppeteer/lib/Page.js:1040:38)
    at Page.<anonymous> (/node_modules/puppeteer/lib/helper.js:112:23)
    at Object.checkout (/node_modules/magepack/lib/generate/collector/checkout.js:71:10)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async module.exports (/node_modules/magepack/lib/generate.js:23:13)
(node:7825) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:7825) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

1  method page.close() need be a await
2 in checkout first of all merge data, only then log a success notification

