### PR TITLE
Add support for compact static deploy mode

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -9,6 +9,7 @@ const getLocales = require('./bundle/getLocales');
 const pathResolver = require('./bundle/pathResolver');
 const checkMinifyOn = require('./bundle/checkMinifyOn');
 const moduleWrapper = require('./bundle/moduleWrapper');
+const modulePathMapper = require('./bundle/moduleMapResolver');
 
 module.exports = async (bundlingConfigPath) => {
     const bundlingConfigRealPath = path.resolve(bundlingConfigPath);
@@ -35,14 +36,15 @@ module.exports = async (bundlingConfigPath) => {
                 isMinifyOn
             );
 
+            const pathMapper = modulePathMapper(localePath, isMinifyOn);
+
             let bundleContents = '';
             const bundledModules = [];
 
             logger.debug(`Collecting modules for "${bundleName}".`);
 
             for (const moduleName in bundle.modules) {
-                const modulePath = path.join(
-                    localePath,
+                const modulePath = pathMapper(
                     pathResolver.getModuleRealPath(
                         moduleName,
                         bundle.modules[moduleName],

--- a/lib/bundle/getLocales.js
+++ b/lib/bundle/getLocales.js
@@ -1,4 +1,6 @@
 const glob = require('glob');
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Returns a list of deployed frontend locales paths excluding Magento blank theme.
@@ -8,7 +10,12 @@ const glob = require('glob');
 const getLocales = () => {
     const locales = glob
         .sync('pub/static/frontend/*/*/*')
-        .filter((locale) => !locale.includes('Magento/blank'));
+        .filter((locale) => !locale.includes('Magento/blank'))
+        .filter(
+            (locale) =>
+                fs.existsSync(path.join(locale, 'requirejs-config.min.js')) ||
+                fs.existsSync(path.join(locale, 'requirejs-config.js'))
+        );
 
     if (!locales.length) {
         throw new Error(

--- a/lib/bundle/moduleMapResolver.js
+++ b/lib/bundle/moduleMapResolver.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const fs = require('fs');
+
+function defaultModulePath(themePath, modulePath) {
+    return path.join(themePath, modulePath);
+}
+
+function mappedModulePath(themePath, modulePath, map) {
+    if (!map[modulePath]) {
+        return defaultModulePath(themePath, modulePath);
+    }
+
+    return path.join(themePath, map[modulePath], modulePath);
+}
+
+module.exports = function (themePath, isMinified) {
+    const bundleMapFile = path.join(
+        themePath,
+        'requirejs-map.' + (isMinified ? 'min.' : '') + 'js'
+    );
+
+    if (fs.existsSync(bundleMapFile)) {
+        const map = new Function(
+            'require',
+            'return ' + fs.readFileSync(bundleMapFile)
+        )({
+            config: (config) => {
+                if (config.config && config.config.baseUrlInterceptor) {
+                    return config.config.baseUrlInterceptor;
+                }
+
+                return {};
+            },
+            map: {},
+        });
+        return function (modulePath) {
+            return mappedModulePath(themePath, modulePath, map);
+        };
+    }
+
+    return function (modulePath) {
+        return defaultModulePath(themePath, modulePath);
+    };
+};

--- a/lib/generate/collectModules.js
+++ b/lib/generate/collectModules.js
@@ -41,9 +41,24 @@ module.exports = async (page) => {
     await page.waitFor(5000);
 
     const modules = await page.evaluate((excludedModules) => {
+        function extractBaseUrl(require) {
+            const baseUrl = require.toUrl('');
+            return baseUrl.replace(/\/[^/]+\/[^/]+\/[^/]+\/[^/]+\/$/, '/');
+        }
+
+        function stripBaseUrl(baseUrl, moduleUrl) {
+            if (!moduleUrl.startsWith(baseUrl)) {
+                return moduleUrl;
+            }
+
+            return moduleUrl
+                .substring(baseUrl.length)
+                .replace(/^[^/]+\/[^/]+\/[^/]+\/[^/]+\//, '');
+        }
+
         const stripPlugin = (moduleName) => moduleName.replace(/^[^!].+!/, '');
 
-        const baseUrlLength = require.toUrl('').length;
+        const baseUrl = extractBaseUrl(require);
 
         const contexts = require.s.contexts;
         const defContext = contexts._;
@@ -70,8 +85,9 @@ module.exports = async (page) => {
                  * Ignore all modules that are loaded with plugins other then text.
                  */
                 if (
-                    moduleName.includes('!') &&
-                    !moduleName.startsWith('text!')
+                    (moduleName.includes('!') &&
+                        !moduleName.startsWith('text!')) ||
+                    moduleName.match(/^https?:\/\//)
                 ) {
                     return;
                 }
@@ -84,13 +100,12 @@ module.exports = async (page) => {
                 }
 
                 /**
-                 * Get module path inside locale directory.
+                 * Get module path from resolved url
                  */
-                const modulePath = unbundledContext.require
-                    .toUrl(stripPlugin(moduleName))
-                    .slice(baseUrlLength);
-
-                modules[moduleName] = modulePath;
+                modules[moduleName] = stripBaseUrl(
+                    baseUrl,
+                    unbundledContext.require.toUrl(stripPlugin(moduleName))
+                );
             }
         );
 


### PR DESCRIPTION
On majority of multi-store Magento installs quick strategy produces
excessive copies of the same static files and takes gigabytes of the
disk space, so default choice of static content deploy schema is
"compact" that dynamically resolves file location via requirejs map
configuration. This pullrequest adds possibility for compact deployment
in magepack by resolving bundles using this map file as well as fixes
bugs with minification detection in compact strategy as not every
locale directory has "requirejs-config.js".

Summary of changes:

- Added resolver of the file location based on requirejs map file for
  compact theme
- Added filter to theme collection of only directories containing
  requirejs-config.js file
- Fix issues with HTML template preloading in compact theme