### PR TITLE
Adding ability to exclude locales while bundling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,13 +38,17 @@ program
         'Configuration file path.',
         'magepack.config.js'
     )
+    .option(
+        '--exclude-locales <code>',
+        'Exclude locales from bundling, comma separated'
+    )
     .option('-d, --debug', 'Enable logging of debugging information.')
-    .action(({ config, debug }) => {
+    .action(({ config, excludeLocales, debug }) => {
         if (debug) {
             logger.level = 5;
         }
 
-        require('./lib/bundle')(config).catch(logger.error);
+        require('./lib/bundle')(config, excludeLocales).catch(logger.error);
     });
 
 program.parse(process.argv);

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -11,14 +11,14 @@ const checkMinifyOn = require('./bundle/checkMinifyOn');
 const moduleWrapper = require('./bundle/moduleWrapper');
 const modulePathMapper = require('./bundle/moduleMapResolver');
 
-module.exports = async (bundlingConfigPath) => {
+module.exports = async (bundlingConfigPath, excludeLocales) => {
     const bundlingConfigRealPath = path.resolve(bundlingConfigPath);
 
     logger.info(`Using bundling config from "${bundlingConfigRealPath}".`);
 
     const bundlingConfig = require(bundlingConfigRealPath);
 
-    const localesPaths = getLocales();
+    const localesPaths = getLocales(excludeLocales);
 
     const isMinifyOn = checkMinifyOn(localesPaths);
 

--- a/lib/bundle/getLocales.js
+++ b/lib/bundle/getLocales.js
@@ -4,18 +4,29 @@ const path = require('path');
 
 /**
  * Returns a list of deployed frontend locales paths excluding Magento blank theme.
+ * @param {string} excludeLocales comma separated locales to exclude from bundling
  *
  * @returns {string[]}
  */
-const getLocales = () => {
+const getLocales = (excludeLocales) => {
+    excludeLocales = excludeLocales || '';
+    
     const locales = glob
         .sync('pub/static/frontend/*/*/*')
         .filter((locale) => !locale.includes('Magento/blank'))
         .filter(
             (locale) =>
+                excludeLocales
+                    .split(',')
+                    .filter((excludeLocale) => locale.includes(excludeLocale))
+                    .length === 0
+        )
+        .filter(
+            (locale) =>
                 fs.existsSync(path.join(locale, 'requirejs-config.min.js')) ||
                 fs.existsSync(path.join(locale, 'requirejs-config.js'))
         );
+
 
     if (!locales.length) {
         throw new Error(


### PR DESCRIPTION
I use this module on every site I build, but during the build/deployment process, it usually takes around a minute to bundle JS.

Because en_US is required for backend (or so I've found, correct me if that's wrong!) we have to deploy both en_US and en_GB.  For this reason I feel it would be helpful to be able to exclude specific locales (I guess it could be used for themes too) from bundling, to speed deployment processes