### PR TITLE
Add output path option to generator command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ program
     .requiredOption('--product-url <url>', 'Product page URL.')
     .option('-u, --auth-username <user>', 'Basic authentication username.')
     .option('-p, --auth-password <password>', 'Basic authentication password.')
+    .option('-o, --output <path>', 'Output file path.')
     .option('-d, --debug', 'Enable logging of debugging information.')
     .action((config) => {
         if (config.debug) {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -41,8 +41,10 @@ module.exports = async (generationConfig) => {
         );
     });
 
+    let outputPath = generationConfig.output || 'magepack.config.js';
+
     fs.writeFileSync(
-        path.resolve('magepack.config.js'),
+        path.resolve(outputPath),
         `module.exports = ${stringify(bundles, null, '  ')}`
     );
 };


### PR DESCRIPTION
It is needed in case when you have several stores on the same instances and you want to split configurations for each one.