### PR TITLE
Fix an issue with "ERROR Execution context was destroyed, most likelybecause of a navigation."

### DIFF
--- a/lib/generate/collector/checkout.js
+++ b/lib/generate/collector/checkout.js
@@ -35,7 +35,7 @@ const checkout = async (
 
     await authenticate(page, authUsername, authPassword);
 
-    await page.goto(productUrl, { waitUntil: 'networkidle0' });
+    await page.goto(productUrl, { waitUntil: 'domcontentloaded' });
 
     // Select option for every swatch if there are any.
     await page.evaluate(() => {
@@ -73,7 +73,7 @@ const checkout = async (
     });
 
     await Promise.all([
-        page.waitForNavigation({ waitUntil: 'networkidle0' }),
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
         page.evaluate(() =>
             document.querySelector('#product_addtocart_form').submit()
         ),
@@ -81,10 +81,10 @@ const checkout = async (
 
     const baseUrl = await page.evaluate(() => BASE_URL);
 
-    await page.goto(`${baseUrl}checkout/cart`, { waitUntil: 'networkidle0' });
+    await page.goto(`${baseUrl}checkout/cart`, { waitUntil: 'domcontentloaded' });
     const cartModules = await collectModules(page);
 
-    await page.goto(`${baseUrl}checkout`, { waitUntil: 'networkidle0' });
+    await page.goto(`${baseUrl}checkout`, { waitUntil: 'domcontentloaded' });
     const checkoutModules = await collectModules(page);
 
     merge(bundleConfig.modules, cartModules, checkoutModules);


### PR DESCRIPTION
```
$ magepack generate --cms-url="https://example.com/" --category-url="https://example.com/category.html" --product-url="https://example.com/some-product-page.html"

ℹ Collecting bundle modules in the browser.                                                                                                                                                                                                       11:55:23
ℹ Collecting modules for bundle "category".                                                                                                                                                                                                       11:55:23
✔ Finished collecting modules for bundle "category".                                                                                                                                                                                              11:55:36
ℹ Collecting modules for bundle "cms".                                                                                                                                                                                                            11:55:36
✔ Finished collecting modules for bundle "cms".                                                                                                                                                                                                   11:55:47
ℹ Collecting modules for bundle "product".                                                                                                                                                                                                        11:55:47
✔ Finished collecting modules for bundle "product".                                                                                                                                                                                               11:55:59
ℹ Collecting modules for bundle "checkout".                                                                                                                                                                                                       11:55:59

 ERROR  Execution context was destroyed, most likely because of a navigation.                                                                                                                                                                     11:56:11

  at rewriteError (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/ExecutionContext.js:167:15)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (node:internal/process/task_queues:94:5)
  at async ExecutionContext._evaluateInternal (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/ExecutionContext.js:120:56)
  at async ExecutionContext.evaluate (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/ExecutionContext.js:48:12)
  at async Object.checkout (/usr/local/lib/node_modules/magepack/lib/generate/collector/checkout.js:82:21)
  at async module.exports (/usr/local/lib/node_modules/magepack/lib/generate.js:24:13)
  -- ASYNC --
  at ExecutionContext.<anonymous> (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/helper.js:111:15)
  at DOMWorld.evaluate (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/DOMWorld.js:112:20)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (node:internal/process/task_queues:94:5)
  -- ASYNC --
  at Frame.<anonymous> (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/helper.js:111:15)
  at Page.evaluate (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/Page.js:860:43)
  at Page.<anonymous> (/usr/local/lib/node_modules/magepack/node_modules/puppeteer/lib/helper.js:112:23)
  at Object.checkout (/usr/local/lib/node_modules/magepack/lib/generate/collector/checkout.js:82:32)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (node:internal/process/task_queues:94:5)
  at async module.exports (/usr/local/lib/node_modules/magepack/lib/generate.js:24:13)
```