### PR TITLE
Handle URLs without scheme

### DIFF
--- a/lib/generate/collectModules.js
+++ b/lib/generate/collectModules.js
@@ -87,7 +87,7 @@ module.exports = async (page) => {
                 if (
                     (moduleName.includes('!') &&
                         !moduleName.startsWith('text!')) ||
-                    moduleName.match(/^https?:\/\//)
+                    moduleName.match(/^(https?:)?\/\//)
                 ) {
                     return;
                 }

--- a/lib/generate/collectModules.js
+++ b/lib/generate/collectModules.js
@@ -82,7 +82,7 @@ module.exports = async (page) => {
         Object.keys(window.require.s.contexts._.defined).forEach(
             (moduleName) => {
                 /**
-                 * Ignore all modules that are loaded with plugins other then text.
+                 * Ignore all modules that are loaded with plugins other than text.
                  */
                 if (
                     (moduleName.includes('!') &&


### PR DESCRIPTION
There exists currently special handling for URLs that begin with `http://` and `https://`, but not for URLs that begin with `//` (ie, which have no scheme). When magepack encounters a URL such as `//unpkg.com/jquery` it does not recognise this as an external asset. This pull request adds handling for the scheme-less URL format.

While I think it's better to always include a scheme, it is technically valid and has been suggested / recommended by some to omit the scheme. Without a scheme specified, the user agent will use the scheme of the current document, so a `http://` page parsing `//www.example.net/` will result in `http://www.example.net/`, and a `https://` page parsing `//www.example.org/` will result in `https://www.example.org/`.