### PR TITLE
Fix selection of configurable attributes not propagating

### DIFF
--- a/lib/generate/collector/checkout.js
+++ b/lib/generate/collector/checkout.js
@@ -69,6 +69,9 @@ const checkout = async (
                 },
                 null
             );
+            
+            select.dispatchEvent(new Event('input', { bubbles: true }));
+            select.dispatchEvent(new Event('change', { bubbles: true }));
         });
     });
 


### PR DESCRIPTION
When selecting the product's options (for configurable products with no swatches), we should then dispatch a "change" and "input" events.
This is implemented here in Puppeteer : https://github.com/puppeteer/puppeteer/blob/dd470c7a226a8422a938a7b0fffa58ffc6b78512/src/common/JSHandle.ts#L597
You can also find more info here : https://github.com/puppeteer/puppeteer/issues/613#issuecomment-330386797

When a product has multiple attributes, we need to select the first attribute option for Magento to fill the other attributes' options. If the "change" event is not fired, the next attribute's options are not loaded, and so we cannot select them and we cannot add the product to the cart.