### PR TITLE
Add options to generate source-maps and minify output irrespective of Magento 2 JS minification setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,22 @@ magepack bundle
 
 This command will iterate over each deployed locale (excluding Magento/blank) and prepare bundles for each of them.
 
-There are two optional params you can set:
+There are multiple optional params you can set:
 
 `-c, --config` - defining the configuration file path, in case you have multiple configuration files (e.g multiple themes with individual configuration files)
 
 `-g, --glob` -  defining where to look for locales to bundle.
+
+`-s, --sourcemap` - enables sourcemap generation for bundled js.
+
+`-m, --minify` - overrides Magento 2 JS minification setting, minifying the bundle using Terser (used by default if Magento 2 JS minification is enabled).
+
+#### Sourcemaps
+
+It is possible to enable sourcemaps for bundled JS files, using the `-s, --sourcemap` flag with `magepack bundle` command. However, there are couple of caveats:
+
+* It does not respect existing sourcemaps for individual JS files (possible future update)
+* For sourcemaps to be meaningful, Magento 2 JS minification must be **turned off**. This is because Magento 2 does not (and cannot with current PHP implementation) generate sourcemaps for each minified JS file. For this reason, a separate `-m, --minify` flag exists to minify the resulting bundle using Terser.
 
 ### Enabling
 

--- a/cli.js
+++ b/cli.js
@@ -45,12 +45,13 @@ program
     )
     .option('-g, --glob <path>', 'Glob pattern of themes to bundle.')
     .option('-d, --debug', 'Enable logging of debugging information.')
-    .action(({ config, debug, glob }) => {
+    .option('-s, --sourcemap', 'Include sourcemaps with generated bundles')
+    .action(({ config, sourcemap, debug, glob }) => {
         if (debug) {
             logger.level = 5;
         }
 
-        require('./lib/bundle')(config, glob).catch(errorHandler);
+        require('./lib/bundle')(config, glob, sourcemap).catch(errorHandler);
     });
 
 program.parse(process.argv);

--- a/cli.js
+++ b/cli.js
@@ -46,12 +46,18 @@ program
     .option('-g, --glob <path>', 'Glob pattern of themes to bundle.')
     .option('-d, --debug', 'Enable logging of debugging information.')
     .option('-s, --sourcemap', 'Include sourcemaps with generated bundles')
-    .action(({ config, sourcemap, debug, glob }) => {
+    .option(
+        '-m, --minify',
+        'Minify bundle using terser irrespective of Magento 2 minification setting'
+    )
+    .action(({ config, sourcemap, minify, debug, glob }) => {
         if (debug) {
             logger.level = 5;
         }
 
-        require('./lib/bundle')(config, glob, sourcemap).catch(errorHandler);
+        require('./lib/bundle')(config, glob, sourcemap, minify).catch(
+            errorHandler
+        );
     });
 
 program.parse(process.argv);

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { stringify } = require('javascript-stringify');
 const terser = require('terser');
 const gzipSize = require('gzip-size');
+const genSourceMap = require('generate-sourcemap');
 
 const logger = require('./utils/logger');
 const getLocales = require('./bundle/getLocales');
@@ -11,7 +12,11 @@ const checkMinifyOn = require('./bundle/checkMinifyOn');
 const moduleWrapper = require('./bundle/moduleWrapper');
 const modulePathMapper = require('./bundle/moduleMapResolver');
 
-module.exports = async (bundlingConfigPath, localesGlobPattern) => {
+module.exports = async (
+    bundlingConfigPath,
+    localesGlobPattern,
+    includeSourcemaps = false
+) => {
     const bundlingConfigRealPath = path.resolve(bundlingConfigPath);
 
     logger.info(`Using bundling config from "${bundlingConfigRealPath}".`);
@@ -37,9 +42,20 @@ module.exports = async (bundlingConfigPath, localesGlobPattern) => {
             );
 
             const pathMapper = modulePathMapper(localePath, isMinifyOn);
+            const bundleFileName = path.basename(bundlePath);
+            const bundlePathDir = path.dirname(bundlePath);
+
+            if (!fs.existsSync(bundlePathDir)) {
+                fs.mkdirSync(path.dirname(bundlePath), { recursive: true });
+            }
 
             let bundleContents = '';
             const bundledModules = [];
+            const sourceMapRanges = [];
+            const sourceRange = {
+                start: 0,
+                end: 0,
+            };
 
             logger.debug(`Collecting modules for "${bundleName}".`);
 
@@ -76,8 +92,17 @@ module.exports = async (bundlingConfigPath, localesGlobPattern) => {
                         );
                     }
 
+                    sourceRange.end =
+                        sourceRange.start +
+                        moduleContents.split(/\r?\n/).length;
                     bundleContents += moduleContents + '\n';
                     bundledModules.push(moduleName);
+                    sourceMapRanges.push({
+                        sourceFile: path.relative(bundlePathDir, modulePath),
+                        start: sourceRange.start,
+                        end: sourceRange.end,
+                    });
+                    sourceRange.start = sourceRange.end;
                 } catch (error) {
                     logger.debug(
                         `Module "${moduleName}", not found under "${modulePath}".`
@@ -87,26 +112,40 @@ module.exports = async (bundlingConfigPath, localesGlobPattern) => {
 
             logger.debug(`Bundle "${bundleName}" collected.`);
 
+            const sourceMap = genSourceMap(bundleFileName);
+            sourceMap.addRanges(sourceMapRanges);
+
             if (isMinifyOn) {
                 logger.debug(`Minifying "${bundleName}" bundle.`);
 
-                const { code, error: minificationError } = terser.minify(
-                    bundleContents,
-                    {
-                        output: {
-                            comments: false,
-                        },
-                        mangle: {
-                            reserved: [
-                                '$',
-                                'jQuery',
-                                'define',
-                                'require',
-                                'exports',
-                            ],
-                        },
-                    }
-                );
+                const terserConfig = {
+                    output: {
+                        comments: false,
+                    },
+                    mangle: {
+                        reserved: [
+                            '$',
+                            'jQuery',
+                            'define',
+                            'require',
+                            'exports',
+                        ],
+                    },
+                };
+
+                if (includeSourcemaps) {
+                    terserConfig.sourceMap = {
+                        content: sourceMap.getMap(),
+                        filename: bundleFileName,
+                        url: `${bundleFileName}.map`,
+                    };
+                }
+
+                const {
+                    code,
+                    map,
+                    error: minificationError,
+                } = terser.minify(bundleContents, terserConfig);
 
                 if (minificationError) {
                     logger.error(minificationError);
@@ -115,16 +154,18 @@ module.exports = async (bundlingConfigPath, localesGlobPattern) => {
                 bundleContents = code;
 
                 logger.debug(`Bundle "${bundleName}" minified.`);
+
+                if (includeSourcemaps) {
+                    fs.writeFileSync(`${bundlePath}.map`, map);
+                }
+            } else if (includeSourcemaps) {
+                bundleContents += `\n//# sourceMappingURL=${bundleFileName}.map\n`;
+                fs.writeFileSync(`${bundlePath}.map`, sourceMap.getMap());
             }
 
             logger.debug(
                 `Writing "${bundleName}" bundle and configuration to disk.`
             );
-
-            const bundlePathDir = path.dirname(bundlePath);
-            if (!fs.existsSync(bundlePathDir)) {
-                fs.mkdirSync(path.dirname(bundlePath), { recursive: true });
-            }
 
             fs.writeFileSync(bundlePath, bundleContents);
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -15,7 +15,8 @@ const modulePathMapper = require('./bundle/moduleMapResolver');
 module.exports = async (
     bundlingConfigPath,
     localesGlobPattern,
-    includeSourcemaps = false
+    includeSourcemaps = false,
+    forceMinify = false
 ) => {
     const bundlingConfigRealPath = path.resolve(bundlingConfigPath);
 
@@ -115,7 +116,7 @@ module.exports = async (
             const sourceMap = genSourceMap(bundleFileName);
             sourceMap.addRanges(sourceMapRanges);
 
-            if (isMinifyOn) {
+            if (isMinifyOn || forceMinify) {
                 logger.debug(`Minifying "${bundleName}" bundle.`);
 
                 const terserConfig = {

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -142,11 +142,10 @@ module.exports = async (
                     };
                 }
 
-                const {
-                    code,
-                    map,
-                    error: minificationError,
-                } = terser.minify(bundleContents, terserConfig);
+                const { code, map, error: minificationError } = terser.minify(
+                    bundleContents,
+                    terserConfig
+                );
 
                 if (minificationError) {
                     logger.error(minificationError);

--- a/lib/generate/collectModules.js
+++ b/lib/generate/collectModules.js
@@ -1,5 +1,3 @@
-/* global window, requestIdleCallback */
-
 const excludedModules = require('./excludedModules');
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,6 +1145,11 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+        },
         "ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -2644,6 +2649,24 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
+        },
+        "generate-sourcemap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/generate-sourcemap/-/generate-sourcemap-0.1.0.tgz",
+            "integrity": "sha1-JiyD7RozEnZk9eRcV8X7Aow0Ez4=",
+            "requires": {
+                "source-map": "~0.1.9"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
+            }
         },
         "gensync": {
             "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "commander": "^5.0.0",
         "consola": "^2.11.3",
+        "generate-sourcemap": "^0.1.0",
         "glob": "^7.1.6",
         "gzip-size": "^5.1.1",
         "javascript-stringify": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,6 +629,11 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -1733,6 +1738,13 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+generate-sourcemap@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/generate-sourcemap/-/generate-sourcemap-0.1.0.tgz#262c83ed1a33127664f5e45c57c5fb028c34133e"
+  integrity sha1-JiyD7RozEnZk9eRcV8X7Aow0Ez4=
+  dependencies:
+    source-map "~0.1.9"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -3776,6 +3788,13 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+source-map@~0.1.9:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
One of the main drawbacks of bundled javascript is that it makes debugging harder. Therefore I believe we should be able to generate source-maps for bundled JS files. To achieve that, I'm using [generate-sourcemap](https://www.npmjs.com/package/generate-sourcemap) package, as it's a straightforward option for simple file concatenation (defining ranges for each concated JS file in the resulting output).

For this, I've added a new option flag: -s or --sourcemap.

For minification, Terser can also use the existing source-map and adjust it for the minified result. However, if Magento 2 modification is enabled, source-maps lose their usability, as Magento 2 uses PHP library for JS minification that does not support source-maps. One way around that is to disable Magento 2 minification and allow Magepack to minify the bundle. 

This is why I've added a second option flag: -m or --minify. This allows us to tell Magepack to use Terser on the result even if Magento 2 JS minification is disabled.

Without source-map:
![image](https://user-images.githubusercontent.com/16865708/148385963-75c97d5f-c288-469a-a997-22a6cc0dcc8c.png)

With source-map:
![image](https://user-images.githubusercontent.com/16865708/148385831-423155c4-b69e-4f67-a173-1e37c639466f.png)

![image](https://user-images.githubusercontent.com/16865708/148387415-4b842278-4b95-48f0-8c28-2bf2fbe2cc94.png)
