### PR TITLE
Improve AMD module detection

### DIFF
--- a/lib/bundle/moduleWrapper.js
+++ b/lib/bundle/moduleWrapper.js
@@ -6,7 +6,7 @@ const jsesc = require('jsesc');
  * @param {string} moduleContents Contents of the module.
  */
 const isNonAmd = (moduleContents) =>
-    !moduleContents.match(/(^|[?;\s}])define\s*\(/m);
+    !moduleContents.match(/(^|[?;\s{}()])define\s*\(/m);
 
 /**
  * Wraps non-AMD module so it can be safely inlined into the bundle.
@@ -52,7 +52,7 @@ const wrapText = (moduleName, content) => {
  */
 const isAnonymousAmd = (moduleContents) =>
     !isNonAmd(moduleContents) &&
-    !moduleContents.match(/(^|[?;\s}])define\s*\(\s*['"]/m);
+    !moduleContents.match(/(^|[?;\s{}()])define\s*\(\s*['"]/m);
 
 /**
  * Changes anonymous AMD module into the named one to be able to bundle it.
@@ -62,7 +62,7 @@ const isAnonymousAmd = (moduleContents) =>
  */
 const wrapAnonymousAmd = (moduleName, moduleContents) =>
     moduleContents.replace(
-        /(^|[?;\s}])define\s*\(/m,
+        /(^|[?;\s{}()])define\s*\(/m,
         `$1define('${moduleName}', `
     );
 

--- a/lib/bundle/moduleWrapper.js
+++ b/lib/bundle/moduleWrapper.js
@@ -6,7 +6,7 @@ const jsesc = require('jsesc');
  * @param {string} moduleContents Contents of the module.
  */
 const isNonAmd = (moduleContents) =>
-    !moduleContents.match(/(^|\s+|;)define\s*\(/m);
+    !moduleContents.match(/(^|[?;\s}])define\s*\(/m);
 
 /**
  * Wraps non-AMD module so it can be safely inlined into the bundle.
@@ -52,7 +52,7 @@ const wrapText = (moduleName, content) => {
  */
 const isAnonymousAmd = (moduleContents) =>
     !isNonAmd(moduleContents) &&
-    !moduleContents.match(/(^|\s+|;)define\s*\(\s*['"]/m);
+    !moduleContents.match(/(^|[?;\s}])define\s*\(\s*['"]/m);
 
 /**
  * Changes anonymous AMD module into the named one to be able to bundle it.
@@ -62,7 +62,7 @@ const isAnonymousAmd = (moduleContents) =>
  */
 const wrapAnonymousAmd = (moduleName, moduleContents) =>
     moduleContents.replace(
-        /(^|\s+|;)define\s*\(/m,
+        /(^|[?;\s}])define\s*\(/m,
         `$1define('${moduleName}', `
     );
 

--- a/lib/bundle/moduleWrapper.test.js
+++ b/lib/bundle/moduleWrapper.test.js
@@ -149,6 +149,30 @@ describe('moduleWrapper module', () => {
                 )
             ).toBe(false);
         });
+
+        test('returns true for minified content with ?define()', () => {
+            expect(
+                moduleWrapper.isAnonymousAmd(
+                    `function(a,b){"use strict";"function"==typeof define&&define.amd?define(["moment"],b):"object"==typeof module&&module.exports?module.exports=b(require("moment")):b(a.moment)}(`
+                )
+            ).toBe(true);
+        });
+
+        test('returns true for minified content with }define()', () => {
+            expect(
+                moduleWrapper.isAnonymousAmd(
+                    `function doNothing(){}define(["jquery"],function myModule () {})`
+                )
+            ).toBe(true);
+        });
+
+        test('returns true for minified content with ;define()', () => {
+            expect(
+                moduleWrapper.isAnonymousAmd(
+                    `function doNothing(){};define(["jquery"],function myModule () {})`
+                )
+            ).toBe(true);
+        });
     });
 
     describe('wrapAnonymousAmd', () => {

--- a/lib/bundle/moduleWrapper.test.js
+++ b/lib/bundle/moduleWrapper.test.js
@@ -166,6 +166,22 @@ describe('moduleWrapper module', () => {
             ).toBe(true);
         });
 
+        test('returns true for minified content with {define()', () => {
+            expect(
+                moduleWrapper.isAnonymousAmd(
+                    `if(true){define(["jquery"],function myModule () {})}`
+                )
+            ).toBe(true);
+        });
+
+        test('returns true for minified content with (define()', () => {
+            expect(
+                moduleWrapper.isAnonymousAmd(
+                    `function doNothing(){};(define(["jquery"],function myModule () {}))`
+                )
+            ).toBe(true);
+        });
+
         test('returns true for minified content with ;define()', () => {
             expect(
                 moduleWrapper.isAnonymousAmd(


### PR DESCRIPTION
Fixes #161
Fixes #162

This may also help with #130.

This should cover cases listed in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion and those discovered in the wild (see #161, #162).