### PR TITLE
Remove unneeded additional RequireJS context

### DIFF
--- a/lib/generate/collectModules.js
+++ b/lib/generate/collectModules.js
@@ -58,24 +58,6 @@ module.exports = async (page) => {
 
         const baseUrl = extractBaseUrl(require);
 
-        const contexts = require.s.contexts;
-        const defContext = contexts._;
-        const defaultContextConfig = defContext.config;
-        const unbundledContextConfig = {
-            baseUrl: defaultContextConfig.baseUrl,
-            paths: defaultContextConfig.paths,
-            shim: defaultContextConfig.shim,
-            config: defaultContextConfig.config,
-            map: defaultContextConfig.map,
-        };
-        const unbundledContext = require.s.newContext('magepack');
-
-        /**
-         * Prepare a separate context where modules are not assigned to bundles.
-         * This make it possible to fetch real module paths even with bundling enabled.
-         */
-        unbundledContext.configure(unbundledContextConfig);
-
         const modules = {};
         Object.keys(window.require.s.contexts._.defined).forEach(
             (moduleName) => {
@@ -102,7 +84,7 @@ module.exports = async (page) => {
                  */
                 modules[moduleName] = stripBaseUrl(
                     baseUrl,
-                    unbundledContext.require.toUrl(stripPlugin(moduleName))
+                    require.toUrl(stripPlugin(moduleName))
                 );
             }
         );


### PR DESCRIPTION
Following #151, the additional RequireJS context seems unnecessary. From the limited testing that I have been able to carry out, `unbundledContext.require.toUrl()` behaves the same as `require.toUrl()` with those assets blocked / not loaded.
This pull request simplifies the logic in `lib/generate/collectModules.js`.