### PR TITLE
Output debug information at debug log level

### DIFF
--- a/lib/generate/blockMagepack.js
+++ b/lib/generate/blockMagepack.js
@@ -10,7 +10,7 @@ const blockMagepack = (page) => {
 
         // If we let these resources load, 'magepack generate' hangs at rjsResolver step.
         if (url.match(/magepack\/requirejs-config-.*\.js$/)) {
-            logger.info('Blocked resource: ' + url);
+            logger.debug('Blocked resource: ' + url);
             request.abort();
             return;
         }


### PR DESCRIPTION
This pull request reduces the logging output when normal operations are happening. The information is available when debugging but does not need to be displayed to all users all the time.